### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/src/utils/load.py
+++ b/src/utils/load.py
@@ -38,7 +38,10 @@ def _load_template(stem: Template) -> DotTemplate:
     try:
         return DotTemplate.read(glob()[stem])
     except KeyError:
-        if (root / stem).is_dir():
+        fullpath = (root / stem).resolve()
+        if not str(fullpath).startswith(str(root.resolve())):
+            raise Exception("Access to the path is not allowed")
+        if fullpath.is_dir():
             return getattr(components, stem)
         raise
 


### PR DESCRIPTION
Fixes [https://github.com/promplate/demo/security/code-scanning/1](https://github.com/promplate/demo/security/code-scanning/1)

To fix the problem, we need to ensure that the constructed file path remains within a safe root directory. This can be achieved by normalizing the path and checking that it starts with the root directory. We will use `os.path.normpath` to normalize the path and then verify that the resulting path starts with the root directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
