### PR TITLE
feat: support `Cerebras` provider

### DIFF
--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -8,6 +8,8 @@ class Config(BaseSettings):
     siliconflow_base_url: str = "https://api.siliconflow.cn/v1/"
     anthropic_api_key: str = ""
     dashscope_api_key: str = ""
+    cerebras_api_key: str = ""
+    cerebras_base_url: str = "https://api.cerebras.ai/v1"
     minimax_api_key: str = ""
     openai_api_key: str = "*"
     openai_base_url: str = ""

--- a/src/utils/llm/__init__.py
+++ b/src/utils/llm/__init__.py
@@ -1,6 +1,7 @@
 from typing import Literal
 
 from .anthropic import anthropic
+from .cerebras import cerebras
 from .chatglm import glm
 from .dispatch import find_llm
 from .groq import groq
@@ -38,7 +39,8 @@ Model = Literal[
     "llama-3.1-8b-instant",
     "llama-3.1-70b-versatile",
     "llama-3.1-405b-reasoning",
-    "llama2-70b-4096",
+    "llama3.1-8b",
+    "llama3.1-70b",
     "mixtral-8x7b-32768",
     "nous-hermes-2-mixtral-8x7b-dpo",
     "qwen-turbo",

--- a/src/utils/llm/cerebras.py
+++ b/src/utils/llm/cerebras.py
@@ -19,6 +19,11 @@ class Cerebras(AsyncChatOpenAI):
     async def generate(self, prompt: str | list[Message], /, **config):
         config = self._run_config | config
 
+        if config.get("response_format") == {"type": "json_object"}:
+            # streaming json is not supported
+            yield await complete(prompt, **config)
+            return
+
         async for token in generate(prompt, **config):
             yield token
 

--- a/src/utils/llm/cerebras.py
+++ b/src/utils/llm/cerebras.py
@@ -6,15 +6,12 @@ from ..config import env
 from .common import client
 from .dispatch import link_llm
 
-complete = AsyncChatComplete(http_client=client, base_url=env.groq_base_url, api_key=env.groq_api_key)
-generate = AsyncChatGenerate(http_client=client, base_url=env.groq_base_url, api_key=env.groq_api_key)
+complete = AsyncChatComplete(http_client=client, base_url=env.cerebras_base_url, api_key=env.cerebras_api_key)
+generate = AsyncChatGenerate(http_client=client, base_url=env.cerebras_base_url, api_key=env.cerebras_api_key)
 
 
-@link_llm("gemma")
-@link_llm("llama3-")
-@link_llm("llama-3.1")
-@link_llm("mixtral")
-class Groq(AsyncChatOpenAI):
+@link_llm("llama3.1")
+class Cerebras(AsyncChatOpenAI):
     async def complete(self, prompt: str | list[Message], /, **config):
         config = self._run_config | config
         return (await complete(prompt, **config)).removeprefix(" ")
@@ -30,8 +27,8 @@ class Groq(AsyncChatOpenAI):
         return self
 
 
-groq = Groq().bind(model="mixtral-8x7b-32768")
+cerebras = Cerebras()
 
 
-groq.complete = patch.chat.acomplete(groq.complete)  # type: ignore
-groq.generate = patch.chat.agenerate(groq.generate)  # type: ignore
+cerebras.complete = patch.chat.acomplete(cerebras.complete)  # type: ignore
+cerebras.generate = patch.chat.agenerate(cerebras.generate)  # type: ignore

--- a/src/utils/llm/groq.py
+++ b/src/utils/llm/groq.py
@@ -22,6 +22,11 @@ class Groq(AsyncChatOpenAI):
     async def generate(self, prompt: str | list[Message], /, **config):
         config = self._run_config | config
 
+        if config.get("response_format") == {"type": "json_object"}:
+            # streaming json is not supported
+            yield await complete(prompt, **config)
+            return
+
         async for token in generate(prompt, **config):
             yield token
 


### PR DESCRIPTION
Resolves #165

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add support for the `Cerebras` provider by implementing asynchronous chat completion and generation functionalities. Update the configuration to include Cerebras API credentials and expand the list of supported LLM models.

New Features:
- Introduce support for the `Cerebras` provider, enabling integration with Cerebras API for asynchronous chat completion and generation.

Enhancements:
- Add new LLM models `llama3.1-8b` and `llama3.1-70b` to the list of supported models.

<!-- Generated by sourcery-ai[bot]: end summary -->